### PR TITLE
Scala 2.8 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
   </scm>
 
   <properties>
-    <scala.version>2.7.4</scala.version>
+    <scala.version>2.8.0</scala.version>
+    <maven-scala-plugin.version>2.14.1</maven-scala-plugin.version>
   </properties>
 
   <repositories>
@@ -81,6 +82,7 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
+        <version>${maven-scala-plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -90,7 +92,7 @@
           </execution>
         </executions>
         <configuration>
-          <scalaVersion>${scala.version}</scalaVersion>
+          <!--<scalaVersion>${scala.version}</scalaVersion>-->
           <args>
             <arg>-target:jvm-1.5</arg>
           </args>
@@ -120,6 +122,7 @@
       <plugin>
         <groupId>org.scala-tools</groupId>
         <artifactId>maven-scala-plugin</artifactId>
+        <version>${maven-scala-plugin.version}</version>
         <configuration>
           <scalaVersion>${scala.version}</scalaVersion>
         </configuration>


### PR DESCRIPTION
I've updated the pom.xml to require Scala 2.8. I've also pinned down the maven-scala-plugin version so the build is repeatable. Please review the change and see if it's an acceptable change to the master branch.

Thanks! Can't wait to see a scala-time release that works with Scala 2.8!
