### PR TITLE
Added Rich Tuples Set making it easier to convert Tuples into DateTime objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ target/
 lib_managed/
 boot/
 src_managed/
+*.iml
+*.ipr
+*.iws

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
       <artifactId>joda-time</artifactId>
       <version>1.6</version>
     </dependency>
-    <!-- <dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.4</version>
@@ -71,7 +71,7 @@
       <artifactId>specs</artifactId>
       <version>1.2.5</version>
       <scope>test</scope>
-    </dependency> -->
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/scala/org/scala_tools/time/Implicits.scala
+++ b/src/main/scala/org/scala_tools/time/Implicits.scala
@@ -71,4 +71,8 @@ trait JodaImplicits {
   implicit def RichReadableInterval(in: ReadableInterval): RichReadableInterval = new RichReadableInterval(in)
   implicit def RichReadablePartial(rp: ReadablePartial): RichReadablePartial = new RichReadablePartial(rp)
   implicit def RichReadablePeriod(per: ReadablePeriod): RichReadablePeriod = new RichReadablePeriod(per)
+  implicit def RichTuple3(tuple3: Tuple3[Int, Int, Int]) = new RichTuple3(tuple3)
+  implicit def RichTuple7(tuple7: Tuple7[Int, Int, Int, Int, Int, Int, Int]) = new RichTuple7(tuple7)
+  implicit def RichTuple8WithStringTZ(tuple8: Tuple8[Int, Int, Int, Int, Int, Int, Int, String]) = new RichTuple8WithStringTZ(tuple8)
+  implicit def RichTuple8WithTZ(tuple8: Tuple8[Int, Int, Int, Int, Int, Int, Int, DateTimeZone]) = new RichTuple8WithTZ(tuple8)
 }

--- a/src/main/scala/org/scala_tools/time/RichTuple3.scala
+++ b/src/main/scala/org/scala_tools/time/RichTuple3.scala
@@ -1,0 +1,32 @@
+package org.scala_tools.time
+
+import org.joda.time._
+
+/** Wrapper that used in an implicit to convert a tuple of year, month, day into
+  *  either a [[java.sql.Date]], a [[java.util.Date]], or [[org.jodatime.DateMidnight]]
+  *
+  *  {{{(2010, 12, 13).toJodaDateTime}}}
+  *     will return a [[org,jodatime.DateMidnight]] object.
+  *
+  *  {{{(2010, 12, 13).toJavaSQLDate}}}
+  *     will return a [[java.sql.Date]] object at midnight on 12/13/2010 UTC.
+  *
+  *  {{{(2010, 12, 13, 19, 10, 13, 120).toJavaDate}}}
+  *     will return a [[java.util.Date]] object at midnight on 12/13/2010 UTC.
+  *
+  * @author Daniel Hinojosa
+  * @param underlying the Tuple3 that will be decorated */
+ class RichTuple3(underlying: Tuple3[Int, Int, Int]) {
+
+  /** Converts the tuple member variable to a [[java.sql.Date]]
+    * @returns [[java.util.Date]] representation of the tuple member variable */
+   def toJavaSQLDate = new java.sql.Date(toJavaDate.getTime)
+
+  /** Converts the tuple member variable to a [[java.util.Date]]
+    * @returns [[java.util.Date]] representation of the tuple member variable */
+   def toJavaDate = toJodaDateMidnight.toDate
+
+  /** Converts the tuple member variable to a [[org.joda.time.DateMidnight]]
+   * @returns [[org.joda.time.DateMidnight]] representation of the tuple member variable */
+   def toJodaDateMidnight = new DateMidnight(underlying._1, underlying._2, underlying._3)
+}

--- a/src/main/scala/org/scala_tools/time/RichTuple7.scala
+++ b/src/main/scala/org/scala_tools/time/RichTuple7.scala
@@ -1,0 +1,33 @@
+package org.scala_tools.time
+
+import org.joda.time.DateTime
+
+/** Wrapper that used in an implicit to convert a tuple of year, month, day, hour, minute, second, and millis into
+  *  either a java.sql.Date, a java.util.Date, or org.jodatime.DateTime
+  *
+  *  {{{(2010, 12, 13, 19, 10, 13, 120).toJodaDateTime}}}
+  *     will return a [[org.jodatime.DateTime]] object at 7:10:13:120 PM on 12/13/2010 UTC.
+  *
+  *  {{{(2010, 12, 13, 19, 10, 13, 120).toJavaSQLDate}}}
+  *     will return a [[java.sql.Date]] object at 7:10:13:120 PM on 12/13/2010 UTC.
+  *
+  *  {{{(2010, 12, 13, 19, 10, 13, 120).toJavaDate}}}
+  *     will return a [[java.util.Date]] object at 7:10:13:120 PM on 12/13/2010 UTC.
+  *
+  * @author Daniel Hinojosa
+  * @param underlying the Tuple7 that will be decorated */
+class RichTuple7(underlying: Tuple7[Int, Int, Int, Int, Int, Int, Int]) {
+
+  /** Converts the tuple member variable to a [[java.sql.Date]]
+    * @returns [[java.util.Date]] representation of the tuple member variable */
+  def toJavaSQLDate = new java.sql.Date(toJavaDate.getTime)
+
+  /** Converts the tuple member variable to a [[java.util.Date]]
+    * @returns [[java.util.Date]] representation of the tuple member variable */
+  def toJavaDate = toJodaDateTime.toDate
+
+  /** Converts the tuple member variable to a [[org.joda.time.DateTime]]
+    * @returns [[org.joda.time.DateTime]] representation of the tuple member variable */
+  def toJodaDateTime = new DateTime(underlying._1, underlying._2, underlying._3, underlying._4, underlying._5,
+    underlying._6, underlying._7)
+}

--- a/src/main/scala/org/scala_tools/time/RichTuple8WithStringTZ.scala
+++ b/src/main/scala/org/scala_tools/time/RichTuple8WithStringTZ.scala
@@ -1,0 +1,34 @@
+package org.scala_tools.time
+
+import org.joda.time.{DateTimeZone, DateTime}
+
+/**  Wrapper that used in an implicit to convert a tuple of year, month, day, hour, minute, second, millis,
+  *  and a String Time Zone ID into either a [[java.sql.Date]], a [[java.util.Date]], or [[org.jodatime.DateTime]]
+  *  in the String time zone provided.
+  *
+  * {{{(2010, 12, 13, 19, 10, 13, 120, "US/Central").toJodaDateTime}}}
+  *     will return a [[org.jodatime.DateTime]] object at 7:10:13:120 PM on 12/13/2010 Central Time
+  *
+  * {{{(2010, 12, 13, 19, 10, 13, 120, "US/Central")).toJavaSQLDate}}}
+  *     will return a [[java.sql.Date]] object at 7:10:13:120 PM on 12/13/2010 Central Time.
+  *
+  * {{{(2010, 12, 13, 19, 10, 13, 120, "US/Central")).toJavaDate}}}
+  *     will return a [[java.util.Date]] object at 7:10:13:120 PM on 12/13/2010 Central Time.
+  *
+  * @author Daniel Hinojosa
+  * @param underlying the Tuple8 that will be decorated */
+class RichTuple8WithStringTZ(underlying: Tuple8[Int, Int, Int, Int, Int, Int, Int, String]) {
+
+  /**Converts the tuple member variable to a [[java.sql.Date]]
+    * @returns [[java.util.Date]] representation of the tuple member variable */
+  def toJavaSQLDate = new java.sql.Date(toJavaDate.getTime)
+
+  /** Converts the tuple member variable to a [[java.util.Date]]
+    * @returns [[java.util.Date]] representation of the tuple member variable */
+  def toJavaDate = toJodaDateTime.toDate
+
+  /** Converts the tuple member variable to a {{{org.joda.time.DateTime}}}
+    * @returns [[org.joda.time.DateTime]] representation of the tuple member variable */
+  def toJodaDateTime = new DateTime(underlying._1, underlying._2, underlying._3, underlying._4, underlying._5,
+    underlying._6, underlying._7, DateTimeZone.forID(underlying._8))
+}

--- a/src/main/scala/org/scala_tools/time/RichTuple8WithTZ.scala
+++ b/src/main/scala/org/scala_tools/time/RichTuple8WithTZ.scala
@@ -1,0 +1,34 @@
+package org.scala_tools.time
+
+import org.joda.time.{DateTimeZone, DateTime}
+
+/**  Wrapper that used in an implicit to convert a tuple of year, month, day, hour, minute, second, millis,
+  *  and a [[org.joda.DateTimeZone]] into either a [[java.sql.Date]], a [[java.util.Date]],
+  *  or [[org.jodatime.DateTime]] in the [[org.joda.DateTimeZone]] provided .
+  *
+  *  {{{(2010, 12, 13, 19, 10, 13, 120, DateTimeZone.forID("US/Central")).toJodaDateTime}}}
+  *     will return a [[org.jodatime.DateTime]] object at 7:10:13:120 PM on 12/13/2010 Central Time
+  *
+  *  {{{(2010, 12, 13, 19, 10, 13, 120, DateTimeZone.forID("US/Central")).toJavaSQLDate}}}
+  *     will return a [[java.sql.Date]] object at 7:10:13:120 PM on 12/13/2010 Central Time.
+  *
+  *  {{{(2010, 12, 13, 19, 10, 13, 120, DateTimeZone.forID("US/Central")).toJavaDate}}}
+  *     will return a [[java.util.Date]] object at 7:10:13:120 PM on 12/13/2010 Central Time.
+  *
+  * @author Daniel Hinojosa
+  * @param underlying the Tuple8 that will be decorated */
+class RichTuple8WithTZ(underlying: Tuple8[Int, Int, Int, Int, Int, Int, Int, DateTimeZone]) {
+
+  /** Converts the tuple member variable to a [[java.sql.Date]]
+    * @returns [[java.util.Date]] representation of the tuple member variable */
+  def toJavaSQLDate = new java.sql.Date(toJavaDate.getTime)
+
+  /** Converts the tuple member variable to a [[java.util.Date]]
+    * @returns [[java.util.Date]] representation of the tuple member variable */
+  def toJavaDate = toJodaDateTime.toDate
+
+  /** Converts the tuple member variable to a [[org.joda.time.DateTime]]
+    * @returns [[org.joda.time.DateTime]] representation of the tuple member variable */
+  def toJodaDateTime = new DateTime(underlying._1, underlying._2, underlying._3, underlying._4, underlying._5,
+    underlying._6, underlying._7, underlying._8)
+}

--- a/src/test/scala/org/scala_tools/time/RichTupleTest.scala
+++ b/src/test/scala/org/scala_tools/time/RichTupleTest.scala
@@ -1,0 +1,25 @@
+package org.scala_tools.time
+
+import org.junit.Test
+
+class RichTupleTest {
+
+  import org.scala_tools.time.Imports._
+
+  @Test def testRichTuple3 {
+    assert(((2010, 12, 13).toJodaDateMidnight.day) == 13)
+  }
+
+  @Test def testRichTuple7 {
+    assert(((2010, 12, 13, 19, 10, 13, 120).toJodaDateTime.getDayOfMonth) == 13)
+  }
+
+  @Test def testRichTuple8WithStringTZ {
+    assert(((2010, 12, 13, 19, 10, 13, 120, "US/Central").toJodaDateTime.getZone.getID) == "America/Chicago")
+  }
+
+  @Test def testRichTuple8WithTZ {
+    assert(((2010, 12, 13, 19, 10, 13, 120, DateTimeZone.forID("US/Central")).toJodaDateTime.getZone.getID) ==
+            "America/Chicago")
+  }
+}


### PR DESCRIPTION
Added Rich Tuples Set making it easier to convert Tuples into DateTime objects.

e.g. (2010, 12, 13).toJodaDateMidnight
e.g. (2010, 12, 13, 19, 10, 13, 120).toJodaDateTime.getDayOfMonth
e.g. (2010, 12, 13, 19, 10, 13, 120, "US/Central").toJodaDateTime
e.g. (2010, 12, 13, 19, 10, 13, 120, DateTimeZone.forID("US/Central")).toJodaDateTime

This is purely to save time to do a tuple -> DateTime conversion and to make code cleaner and friendly.

Also offered toSqlDate and toJavaDate methods to quickly convert Tuples to javax.sql.Date and java.util.Date in case interoperability with Java is required.

Note: Turned on junit dependency to run tests.
