### PR TITLE
adds an implicit val for Ordering[DateTime]

### DIFF
--- a/src/main/scala/org/scala_tools/time/Implicits.scala
+++ b/src/main/scala/org/scala_tools/time/Implicits.scala
@@ -26,9 +26,10 @@ import org.joda.time.field.AbstractReadableInstantFieldProperty
 object Implicits extends Implicits
 object BuilderImplicits extends Implicits
 object IntImplicits extends IntImplicits
+object OrderingImplicits extends OrderingImplicits
 object JodaImplicits extends JodaImplicits
 
-trait Implicits extends BuilderImplicits with IntImplicits with DateImplicits with JodaImplicits
+trait Implicits extends BuilderImplicits with IntImplicits with DateImplicits with OrderingImplicits with JodaImplicits
 
 trait BuilderImplicits {
   implicit def forcePeriod(builder: DurationBuilder): Period =
@@ -44,6 +45,12 @@ trait IntImplicits {
 
 trait DateImplicits {
   implicit def RichDate(d: Date): RichDate = new org.scala_tools.time.RichDate(d)
+}
+
+trait OrderingImplicits {
+  implicit val DateTimeOrdering = new Ordering[DateTime] {
+    def compare(a: DateTime, b: DateTime) = a.compareTo(b)
+  }
 }
 
 trait JodaImplicits {

--- a/src/main/scala/org/scala_tools/time/Implicits.scala
+++ b/src/main/scala/org/scala_tools/time/Implicits.scala
@@ -51,6 +51,10 @@ trait OrderingImplicits {
   implicit val DateTimeOrdering = new Ordering[DateTime] {
     def compare(a: DateTime, b: DateTime) = a.compareTo(b)
   }
+
+  implicit val LocalDateOrdering = new Ordering[LocalDate] {
+    def compare(a: LocalDate, b: LocalDate) = a.compareTo(b)
+  }
 }
 
 trait JodaImplicits {


### PR DESCRIPTION
OLD:

  scala> import org.scala_tools.time.Imports._
  import org.scala_tools.time.Imports._

  scala> val l = List(DateTime.now)
  l: List[org.joda.time.DateTime] = List(2012-03-28T21:21:38.573+02:00)

  scala> l min
  <console>:64: error: No implicit Ordering defined for org.joda.time.DateTime.
                l min
                  ^

NEW:

  scala> import org.scala_tools.time.Imports._
  import org.scala_tools.time.Imports._

  scala> val l = List(DateTime.now)
  l: List[org.joda.time.DateTime] = List(2012-03-28T21:22:12.842+02:00)

  scala> l min
  res0: org.joda.time.DateTime = 2012-03-28T21:22:12.842+02:00
