### PR TITLE
Builds 2.10 artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,16 +6,7 @@ version := "0.7-SNAPSHOT"
 
 publishMavenStyle := true
 
-crossScalaVersions := Seq("2.8.0", "2.8.1", "2.9.0", "2.9.0-1", "2.9.1", "2.9.2", "2.10.0-M7")
-
-crossVersion := CrossVersion.full
-
-scalaBinaryVersion <<= scalaBinaryVersion { v =>
-  if (v.startsWith("2.10"))
-    "2.10.0-M7"
-  else
-    v
-}
+crossScalaVersions := Seq("2.8.0", "2.8.1", "2.9.0", "2.9.0-1", "2.9.1", "2.9.2", "2.10.0")
 
 scalacOptions <++= scalaVersion map { v =>
   if (v.startsWith("2.10"))


### PR DESCRIPTION
Hi Jorge,

  apparently my modifications to build.sbt are producing correctly a artifact for 2.10.

```
      "org.scalaj" %% "scalaj-time" % "0.7-SNAPSHOT"  seems to work.
```

Would you review this and publish a 2.10 artifact to maven central?

Thank you!
