### PR TITLE
update libraries version and add scala 2.10.4, 2.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,12 +6,14 @@ version := "0.8-SNAPSHOT"
 
 publishMavenStyle := true
 
-crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1", "2.9.1-1", "2.9.2", "2.10.4")
+crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1", "2.9.1-1", "2.9.2", "2.10.4", "2.11.0")
 
 crossVersion := CrossVersion.full
 
+scalaVersion := "2.11.0"
+
 scalacOptions <++= scalaVersion map { v =>
-  if (v.startsWith("2.10"))
+  if (v.startsWith("2.1"))
     Seq("-unchecked", "-deprecation", "-feature", "-language:implicitConversions")
   else
     Seq("-unchecked", "-deprecation")

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "0.8-SNAPSHOT"
 
 publishMavenStyle := true
 
-crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1", "2.9.1-1", "2.9.2", "2.10.2")
+crossScalaVersions := Seq("2.9.0", "2.9.0-1", "2.9.1", "2.9.1-1", "2.9.2", "2.10.4")
 
 crossVersion := CrossVersion.full
 
@@ -18,8 +18,8 @@ scalacOptions <++= scalaVersion map { v =>
 }
 
 libraryDependencies ++= Seq(
-  "joda-time" % "joda-time" % "2.2",
-  "org.joda" % "joda-convert" % "1.2" % "compile"
+  "joda-time" % "joda-time" % "2.3",
+  "org.joda" % "joda-convert" % "1.6" % "compile"
 )
 
 pomExtra := (

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.2

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")

--- a/src/main/scala/org/scala_tools/time/Implicits.scala
+++ b/src/main/scala/org/scala_tools/time/Implicits.scala
@@ -53,7 +53,7 @@ trait JodaImplicits {
   implicit def RichAbstractReadableInstantFieldProperty(pty: AbstractReadableInstantFieldProperty): RichAbstractReadableInstantFieldProperty =
     new RichAbstractReadableInstantFieldProperty(pty)
   implicit def RichChronology(ch: Chronology): RichChronology = new RichChronology(ch)
-  implicit def RichDateMidnight(dm: DateMidnight): RichDateMidnight = new RichDateMidnight(dm)
+  implicit def RichDateMidnight(dm: JodaTimeDateMidnight): RichDateMidnight = new RichDateMidnight(dm)
   implicit def RichDateTime(dt: DateTime): RichDateTime = new RichDateTime(dt)
   implicit def RichDateTimeFormatter(fmt: DateTimeFormatter): RichDateTimeFormatter = new RichDateTimeFormatter(fmt)
   implicit def RichDateTimeProperty(pty: DateTime.Property): RichDateTimeProperty = new RichDateTimeProperty(pty)

--- a/src/main/scala/org/scala_tools/time/RichDateMidnight.scala
+++ b/src/main/scala/org/scala_tools/time/RichDateMidnight.scala
@@ -18,21 +18,21 @@ package org.scala_tools.time
 
 import org.joda.time._
 
-class RichDateMidnight(underlying: DateMidnight) {
-  def -(duration: Long): DateMidnight =
+class RichDateMidnight(underlying: JodaTimeDateMidnight) {
+  def -(duration: Long): JodaTimeDateMidnight =
     underlying.minus(duration)
-  def -(duration: ReadableDuration): DateMidnight =
+  def -(duration: ReadableDuration): JodaTimeDateMidnight =
     underlying.minus(duration)
-  def -(period: ReadablePeriod): DateMidnight =
+  def -(period: ReadablePeriod): JodaTimeDateMidnight =
     underlying.minus(period)
-  def -(builder: DurationBuilder): DateMidnight =
+  def -(builder: DurationBuilder): JodaTimeDateMidnight =
     underlying.minus(builder.underlying)
-  def +(duration: Long): DateMidnight =
+  def +(duration: Long): JodaTimeDateMidnight =
     underlying.plus(duration)
-  def +(duration: ReadableDuration): DateMidnight =
+  def +(duration: ReadableDuration): JodaTimeDateMidnight =
     underlying.plus(duration)
-  def +(period: ReadablePeriod): DateMidnight =
+  def +(period: ReadablePeriod): JodaTimeDateMidnight =
     underlying.plus(period)
-  def +(builder: DurationBuilder): DateMidnight =
+  def +(builder: DurationBuilder): JodaTimeDateMidnight =
     underlying.plus(builder.underlying)
 }

--- a/src/main/scala/org/scala_tools/time/package.scala
+++ b/src/main/scala/org/scala_tools/time/package.scala
@@ -1,0 +1,6 @@
+package org.scala_tools
+
+package object time {
+  // define in order to collect the deprecated warning message
+  type JodaTimeDateMidnight = org.joda.time.DateMidnight
+}


### PR DESCRIPTION
Update crossScalaVersions for Scala 2.11.0
and misc modifications.
- replace Scala 2.10.2 with Scala 2.10.4 at crossScalaVersions
- update dependent libraries version
- add build.properties to use specify sbt version
- org.joda.time.DateMidnight is deprecated since joda-time 2.3, so compiler output many deprecated warning messages.
  So define type alias, output only one message.
